### PR TITLE
Respect Ingress backend

### DIFF
--- a/controller.go
+++ b/controller.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/golang/glog"
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	extensionsV1beta1 "k8s.io/api/extensions/v1beta1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -377,11 +377,9 @@ func (c *Controller) Process(ctx context.Context) {
 		}
 		annotations[ResultAnnotation] = "true"
 
-		if dataBackend, exists := configMap.Data[BackendConfigKey]; exists {
-			if err := yaml.Unmarshal([]byte(dataBackend), &backend); err != nil {
-				backend = nil
-				glog.Errorf("Could not unmarshal [%s] from config [%s/%s]: %v", BackendConfigKey, configMap.Namespace, configMap.Name, err)
-			}
+		backend, err := getDefaultBackend(configMap, ingresses)
+		if err != nil {
+			glog.Errorf(err.Error())
 		}
 
 		mergedIngres := &extensionsV1beta1.Ingress{
@@ -495,4 +493,32 @@ func hasIngressChanged(old, new *extensionsV1beta1.Ingress) bool {
 	}
 
 	return false
+}
+
+func getDefaultBackend(configMap *v1.ConfigMap, ingresses []*extensionsV1beta1.Ingress) (*extensionsV1beta1.IngressBackend, error) {
+	var backend *extensionsV1beta1.IngressBackend
+
+	for _, i := range ingresses {
+		if i.Spec.Backend != nil {
+			if backend != nil {
+				return nil, fmt.Errorf("default backend detected in multiple Ingress resources for config [%s/%s]", configMap.Namespace, configMap.Name)
+			}
+
+			backend = i.Spec.Backend
+			continue
+		}
+	}
+
+	dataBackend, exists := configMap.Data[BackendConfigKey]
+	if exists {
+		if backend != nil {
+			return nil, fmt.Errorf("multiple default backends detected in Ingress and in ConfigMap for config [%s/%s]", configMap.Namespace, configMap.Name)
+		}
+
+		if err := yaml.Unmarshal([]byte(dataBackend), &backend); err != nil {
+			return nil, fmt.Errorf("Could not unmarshal [%s] from config [%s/%s]: %v", BackendConfigKey, configMap.Namespace, configMap.Name, err)
+		}
+	}
+
+	return backend, nil
 }

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -20,9 +20,9 @@ rbac:
   serviceAccountName: default
 
 image:
-  repository: jakubkulhan/ingress-merge
+  repository: kinvey/ingress-merge
   tag: latest
-  pullPolicy: Always
+  pullPolicy: Never
 
 resources: {}
 

--- a/test.yaml
+++ b/test.yaml
@@ -1,0 +1,59 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: merged-ingress
+  namespace: default
+data:
+  annotations: |
+    kubernetes.io/ingress.class: alb
+  backend: |
+    serviceName: cm
+    servicePort: 80
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: src-first
+  labels:
+    app: app
+  annotations:
+    kubernetes.io/ingress.class: merge
+    merge.ingress.kubernetes.io/config: merged-ingress
+spec:
+  rules:
+    - host: first.example.com
+      http:
+        paths:
+          - path: /*
+            backend:
+              serviceName: first
+              servicePort: 80
+  # backend:
+  #   serviceName: ing
+  #   servicePort: 80
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: src-second
+  labels:
+    app: app
+  annotations:
+    kubernetes.io/ingress.class: merge
+    merge.ingress.kubernetes.io/config: merged-ingress
+spec:
+  rules:
+    - host: second.example.com
+      http:
+        paths:
+          - path: /*
+            backend:
+              serviceName: second
+              servicePort: 80
+  # backend:
+  #   serviceName: invalid-ing
+  #   servicePort: 80


### PR DESCRIPTION
# Purpose

Respect the `backend` configuration of Ingress resources.
The only supported backend configurations are backend in single Ingress resource or backend in ConfigMap.